### PR TITLE
always lowercase email address

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -126,4 +126,8 @@ class User extends Authenticatable
     {
         return $this->force_update ?? null;
     }
+
+    public function setEmailAttribute($value){
+        $this->attributes['email'] = strtolower($value);
+    }
 }


### PR DESCRIPTION
always lowercase email addresses before saving to the users' table
I added a mutation on the User model that transforms email address to lower case before saving it to the user table