### PR TITLE
feat: improve ui / ux of period resource settings

### DIFF
--- a/app/Filament/Resources/Courses/CourseResource.php
+++ b/app/Filament/Resources/Courses/CourseResource.php
@@ -19,7 +19,6 @@ use Filament\Actions\EditAction;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\ColorPicker;
 use Filament\Forms\Components\DatePicker;
-use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;

--- a/app/Filament/Resources/Periods/PeriodResource.php
+++ b/app/Filament/Resources/Periods/PeriodResource.php
@@ -81,6 +81,9 @@ class PeriodResource extends Resource
 
     public static function table(Table $table): Table
     {
+        $currentPeriodId = Config::where('name', 'current_period')->first()?->value;
+        $enrollmentPeriodId = Config::where('name', 'default_enrollment_period')->first()?->value;
+
         return $table
             ->columns([
                 TextColumn::make('year.name')
@@ -98,6 +101,27 @@ class PeriodResource extends Resource
                     ->label(__('End Date'))
                     ->date()
                     ->sortable(),
+                TextColumn::make('id')
+                    ->label(__('Status'))
+                    ->badge()
+                    ->formatStateUsing(function (Period $record) use ($currentPeriodId, $enrollmentPeriodId) {
+                        $badges = [];
+                        if ((string) $record->id === (string) $currentPeriodId) {
+                            $badges[] = __('Current');
+                        }
+                        if ((string) $record->id === (string) $enrollmentPeriodId) {
+                            $badges[] = __('Enrollment');
+                        }
+
+                        return implode(' | ', $badges) ?: null;
+                    })
+                    ->color(fn (Period $record) => match (true) {
+                        (string) $record->id === (string) $currentPeriodId && (string) $record->id === (string) $enrollmentPeriodId => 'primary',
+                        (string) $record->id === (string) $currentPeriodId => 'success',
+                        (string) $record->id === (string) $enrollmentPeriodId => 'info',
+                        default => 'gray',
+                    })
+                    ->placeholder('-'),
                 IconColumn::make('archived')
                     ->label(__('Archived'))
                     ->boolean(),
@@ -114,6 +138,7 @@ class PeriodResource extends Resource
                     ->icon('heroicon-m-check-circle')
                     ->color('success')
                     ->requiresConfirmation()
+                    ->hidden(fn (Period $record) => (string) $record->id === (string) $currentPeriodId)
                     ->action(function (Period $record) {
                         Config::updateOrCreate(['name' => 'current_period'], ['value' => $record->id]);
 
@@ -128,6 +153,7 @@ class PeriodResource extends Resource
                     ->icon('heroicon-m-academic-cap')
                     ->color('info')
                     ->requiresConfirmation()
+                    ->hidden(fn (Period $record) => (string) $record->id === (string) $enrollmentPeriodId)
                     ->action(function (Period $record) {
                         Config::updateOrCreate(['name' => 'default_enrollment_period'], ['value' => $record->id]);
 


### PR DESCRIPTION
## Description
Improve the Period settings resource by adding status badges showing which period is the "Current" and/or "Enrollment" period, and hiding redundant action buttons.

## Ticket
https://www.notion.so/316056d4190e80b6855eca330f9f77fd

## Changes
- **PeriodResource**: Added a "Status" badge column showing "Current" (green), "Enrollment" (blue), or both (primary) labels
- **PeriodResource**: Action buttons ("Set as current", "Set as enrollment period") are now hidden when the period already holds that status
- Action buttons remain available for periods that are NOT yet current/enrollment

## Tests
- [x] Tests automatisés : ✅ passés (321 passed, 1 skipped)
- [x] Linter : ✅ passé

## Notes
- The "Archived" toggle remains unchanged — it controls the `active()` scope, which excludes archived periods from queries throughout the app
- The badge uses `formatStateUsing` on the `id` column to dynamically compute status labels