### PR TITLE
feat: improve the ux of action buttons in filament tables

### DIFF
--- a/app/Filament/Resources/Courses/CourseResource.php
+++ b/app/Filament/Resources/Courses/CourseResource.php
@@ -19,7 +19,6 @@ use Filament\Actions\EditAction;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\ColorPicker;
 use Filament\Forms\Components\DatePicker;
-use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;

--- a/app/Filament/Resources/Events/EventResource.php
+++ b/app/Filament/Resources/Events/EventResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Events;
 use App\Filament\Resources\Events\Pages\ListEvents;
 use App\Models\Event;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -144,7 +145,9 @@ class EventResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/ExternalCourses/ExternalCourseResource.php
+++ b/app/Filament/Resources/ExternalCourses/ExternalCourseResource.php
@@ -6,6 +6,7 @@ use App\Filament\Resources\ExternalCourses\Pages\ManageExternalCourses;
 use App\Models\Course;
 use App\Models\Period;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -193,7 +194,9 @@ class ExternalCourseResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Invoices/InvoiceResource.php
+++ b/app/Filament/Resources/Invoices/InvoiceResource.php
@@ -11,11 +11,11 @@ use App\Models\Invoice;
 use App\Services\InvoiceService;
 use BackedEnum;
 use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
-use Filament\Actions\ViewAction;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -162,8 +162,6 @@ class InvoiceResource extends Resource
                     ->preload(),
             ])
             ->recordActions([
-                ViewAction::make(),
-                EditAction::make(),
                 Action::make('download_pdf')
                     ->label(__('PDF'))
                     ->icon(Heroicon::OutlinedArrowDownTray)
@@ -174,7 +172,10 @@ class InvoiceResource extends Resource
                             echo $service->download($record)->stream()->getContent();
                         }, 'invoice-'.($record->invoice_reference ?? $record->id).'.pdf');
                     }),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    EditAction::make(),
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Leaves/LeaveResource.php
+++ b/app/Filament/Resources/Leaves/LeaveResource.php
@@ -7,10 +7,10 @@ use App\Filament\Resources\Leaves\Pages\EditLeave;
 use App\Filament\Resources\Leaves\Pages\ListLeaves;
 use App\Models\Leave;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
-use Filament\Actions\EditAction;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Select;
 use Filament\Resources\Resource;
@@ -108,8 +108,9 @@ class LeaveResource extends Resource
                     }),
             ])
             ->recordActions([
-                EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Members/MemberResource.php
+++ b/app/Filament/Resources/Members/MemberResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Members;
 use App\Filament\Resources\Members\Pages\ManageMembers;
 use App\Models\Member;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -79,7 +80,9 @@ class MemberResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Partners/PartnerResource.php
+++ b/app/Filament/Resources/Partners/PartnerResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Partners;
 use App\Filament\Resources\Partners\Pages\ManagePartners;
 use App\Models\Partner;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -97,7 +98,9 @@ class PartnerResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Periods/PeriodResource.php
+++ b/app/Filament/Resources/Periods/PeriodResource.php
@@ -7,6 +7,7 @@ use App\Models\Config;
 use App\Models\Period;
 use BackedEnum;
 use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -138,7 +139,9 @@ class PeriodResource extends Resource
                             ->send();
                     }),
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/ScheduledPayments/ScheduledPaymentResource.php
+++ b/app/Filament/Resources/ScheduledPayments/ScheduledPaymentResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\ScheduledPayments;
 use App\Filament\Resources\ScheduledPayments\Pages\ManageScheduledPayments;
 use App\Models\ScheduledPayment;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -122,7 +123,9 @@ class ScheduledPaymentResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Scholarships/ScholarshipResource.php
+++ b/app/Filament/Resources/Scholarships/ScholarshipResource.php
@@ -5,10 +5,10 @@ namespace App\Filament\Resources\Scholarships;
 use App\Filament\Resources\Scholarships\Pages\ManageScholarships;
 use App\Models\Scholarship;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
-use Filament\Actions\EditAction;
 use Filament\Actions\ForceDeleteAction;
 use Filament\Actions\ForceDeleteBulkAction;
 use Filament\Actions\RestoreAction;
@@ -72,10 +72,11 @@ class ScholarshipResource extends Resource
                 TrashedFilter::make(),
             ])
             ->recordActions([
-                EditAction::make(),
-                DeleteAction::make(),
-                ForceDeleteAction::make(),
-                RestoreAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                    ForceDeleteAction::make(),
+                    RestoreAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/AttendanceTypes/AttendanceTypeResource.php
+++ b/app/Filament/Resources/Settings/AttendanceTypes/AttendanceTypeResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\AttendanceTypes;
 use App\Filament\Resources\Settings\AttendanceTypes\Pages\ManageAttendanceTypes;
 use App\Models\AttendanceType;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -70,7 +71,9 @@ class AttendanceTypeResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/Books/BookResource.php
+++ b/app/Filament/Resources/Settings/Books/BookResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\Books;
 use App\Filament\Resources\Settings\Books\Pages\ManageBooks;
 use App\Models\Book;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -81,7 +82,9 @@ class BookResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/Campuses/CampusResource.php
+++ b/app/Filament/Resources/Settings/Campuses/CampusResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\Campuses;
 use App\Filament\Resources\Settings\Campuses\Pages\ManageCampuses;
 use App\Models\Campus;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -70,9 +71,11 @@ class CampusResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
-                ForceDeleteAction::make(),
-                RestoreAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                    ForceDeleteAction::make(),
+                    RestoreAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/ContactRelationships/ContactRelationshipResource.php
+++ b/app/Filament/Resources/Settings/ContactRelationships/ContactRelationshipResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\ContactRelationships;
 use App\Filament\Resources\Settings\ContactRelationships\Pages\ManageContactRelationships;
 use App\Models\ContactRelationship;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -63,7 +64,9 @@ class ContactRelationshipResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/Coupons/CouponResource.php
+++ b/app/Filament/Resources/Settings/Coupons/CouponResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\Coupons;
 use App\Filament\Resources\Settings\Coupons\Pages\ManageCoupons;
 use App\Models\Coupon;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -74,7 +75,9 @@ class CouponResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/Discounts/DiscountResource.php
+++ b/app/Filament/Resources/Settings/Discounts/DiscountResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\Discounts;
 use App\Filament\Resources\Settings\Discounts\Pages\ManageDiscounts;
 use App\Models\Discount;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -78,7 +79,9 @@ class DiscountResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/EvaluationTypes/EvaluationTypeResource.php
+++ b/app/Filament/Resources/Settings/EvaluationTypes/EvaluationTypeResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\EvaluationTypes;
 use App\Filament\Resources\Settings\EvaluationTypes\Pages\ManageEvaluationTypes;
 use App\Models\EvaluationType;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -79,7 +80,9 @@ class EvaluationTypeResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/Fees/FeeResource.php
+++ b/app/Filament/Resources/Settings/Fees/FeeResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\Fees;
 use App\Filament\Resources\Settings\Fees\Pages\ManageFees;
 use App\Models\Fee;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -90,7 +91,9 @@ class FeeResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/GradeTypeCategories/GradeTypeCategoryResource.php
+++ b/app/Filament/Resources/Settings/GradeTypeCategories/GradeTypeCategoryResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\GradeTypeCategories;
 use App\Filament\Resources\Settings\GradeTypeCategories\Pages\ManageGradeTypeCategories;
 use App\Models\GradeTypeCategory;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -66,7 +67,9 @@ class GradeTypeCategoryResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/GradeTypes/GradeTypeResource.php
+++ b/app/Filament/Resources/Settings/GradeTypes/GradeTypeResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\GradeTypes;
 use App\Filament\Resources\Settings\GradeTypes\Pages\ManageGradeTypes;
 use App\Models\GradeType;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -83,7 +84,9 @@ class GradeTypeResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/Institutions/InstitutionResource.php
+++ b/app/Filament/Resources/Settings/Institutions/InstitutionResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\Institutions;
 use App\Filament\Resources\Settings\Institutions\Pages\ManageInstitutions;
 use App\Models\Institution;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -65,7 +66,9 @@ class InstitutionResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/LeaveTypes/LeaveTypeResource.php
+++ b/app/Filament/Resources/Settings/LeaveTypes/LeaveTypeResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\LeaveTypes;
 use App\Filament\Resources\Settings\LeaveTypes\Pages\ManageLeaveTypes;
 use App\Models\LeaveType;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -63,7 +64,9 @@ class LeaveTypeResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/Levels/LevelResource.php
+++ b/app/Filament/Resources/Settings/Levels/LevelResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\Levels;
 use App\Filament\Resources\Settings\Levels\Pages\ManageLevels;
 use App\Models\Level;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -79,9 +80,11 @@ class LevelResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
-                ForceDeleteAction::make(),
-                RestoreAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                    ForceDeleteAction::make(),
+                    RestoreAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/Paymentmethods/PaymentmethodResource.php
+++ b/app/Filament/Resources/Settings/Paymentmethods/PaymentmethodResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\Paymentmethods;
 use App\Filament\Resources\Settings\Paymentmethods\Pages\ManagePaymentmethods;
 use App\Models\Paymentmethod;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -73,7 +74,9 @@ class PaymentmethodResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/ResultTypes/ResultTypeResource.php
+++ b/app/Filament/Resources/Settings/ResultTypes/ResultTypeResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\ResultTypes;
 use App\Filament\Resources\Settings\ResultTypes\Pages\ManageResultTypes;
 use App\Models\ResultType;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -74,7 +75,9 @@ class ResultTypeResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/Rhythms/RhythmResource.php
+++ b/app/Filament/Resources/Settings/Rhythms/RhythmResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\Rhythms;
 use App\Filament\Resources\Settings\Rhythms\Pages\ManageRhythms;
 use App\Models\Rhythm;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -85,9 +86,11 @@ class RhythmResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
-                ForceDeleteAction::make(),
-                RestoreAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                    ForceDeleteAction::make(),
+                    RestoreAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/Rooms/RoomResource.php
+++ b/app/Filament/Resources/Settings/Rooms/RoomResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\Rooms;
 use App\Filament\Resources\Settings\Rooms\Pages\ManageRooms;
 use App\Models\Room;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -88,9 +89,11 @@ class RoomResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
-                ForceDeleteAction::make(),
-                RestoreAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                    ForceDeleteAction::make(),
+                    RestoreAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/SkillScales/SkillScaleResource.php
+++ b/app/Filament/Resources/Settings/SkillScales/SkillScaleResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\SkillScales;
 use App\Filament\Resources\Settings\SkillScales\Pages\ManageSkillScales;
 use App\Models\Skills\SkillScale;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -85,7 +86,9 @@ class SkillScaleResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/SkillTypes/SkillTypeResource.php
+++ b/app/Filament/Resources/Settings/SkillTypes/SkillTypeResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\SkillTypes;
 use App\Filament\Resources\Settings\SkillTypes\Pages\ManageSkillTypes;
 use App\Models\Skills\SkillType;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -76,7 +77,9 @@ class SkillTypeResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/Skills/SkillResource.php
+++ b/app/Filament/Resources/Settings/Skills/SkillResource.php
@@ -6,6 +6,7 @@ use App\Filament\Resources\Settings\Skills\Pages\ManageSkills;
 use App\Models\Skills\Skill;
 use App\Models\Skills\SkillType;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -94,7 +95,9 @@ class SkillResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/Taxes/TaxResource.php
+++ b/app/Filament/Resources/Settings/Taxes/TaxResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\Taxes;
 use App\Filament\Resources\Settings\Taxes\Pages\ManageTaxes;
 use App\Models\Tax;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -77,7 +78,9 @@ class TaxResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Settings/Years/YearResource.php
+++ b/app/Filament/Resources/Settings/Years/YearResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Settings\Years;
 use App\Filament\Resources\Settings\Years\Pages\ManageYears;
 use App\Models\Year;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -66,7 +67,9 @@ class YearResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                ActionGroup::make([
+                    DeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/Teachers/TeacherResource.php
+++ b/app/Filament/Resources/Teachers/TeacherResource.php
@@ -7,9 +7,9 @@ use App\Filament\Resources\Teachers\Pages\EditTeacher;
 use App\Filament\Resources\Teachers\Pages\ListTeachers;
 use App\Models\Teacher;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
-use Filament\Actions\EditAction;
 use Filament\Actions\ForceDeleteAction;
 use Filament\Actions\ForceDeleteBulkAction;
 use Filament\Actions\RestoreAction;
@@ -104,9 +104,10 @@ class TeacherResource extends Resource
                 TrashedFilter::make(),
             ])
             ->recordActions([
-                EditAction::make(),
-                RestoreAction::make(),
-                ForceDeleteAction::make(),
+                ActionGroup::make([
+                    RestoreAction::make(),
+                    ForceDeleteAction::make(),
+                ]),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([


### PR DESCRIPTION
## Description
Systematically improve the UX of action buttons across all Filament table resources by moving delete actions into action drawers and removing redundant edit buttons.

## Ticket
https://www.notion.so/316056d4190e804b833dd54cdc51d243

## Changes

**33 files modified** following these rules:

### ManageRecords resources (modal editing — 28 resources)
- Keep EditAction inline (needed for modal edit)
- Wrap DeleteAction (and ForceDeleteAction/RestoreAction where present) in ActionGroup drawer

### Page-based resources WITHOUT show view (3 resources)
- **TeacherResource**: Removed EditAction (row click = edit), wrapped RestoreAction + ForceDeleteAction in ActionGroup
- **LeaveResource**: Removed EditAction, wrapped DeleteAction in ActionGroup
- **ScholarshipResource**: Removed EditAction, wrapped DeleteAction + ForceDeleteAction + RestoreAction in ActionGroup

### Page-based resources WITH show view (1 resource)
- **InvoiceResource**: Removed ViewAction (row click = show view), kept PDF download inline, moved EditAction + DeleteAction to ActionGroup

## Tests
- [x] Tests automatisés : ✅ passés (321 passed, 1 skipped)
- [x] Linter : ✅ passé

## Notes
- CourseResource was already following this pattern and was not modified
- EnrollmentResource and StudentResource have custom action configurations and were not modified
- The PDF download action on InvoiceResource stays inline for quick access